### PR TITLE
Django 1.8 compatibility.

### DIFF
--- a/django_like/__init__.py
+++ b/django_like/__init__.py
@@ -1,6 +1,8 @@
 import django
 
-from django.db import backend
+from django.db import connection
+
+_backend_name = connection.vendor.lower()
 
 
 if django.VERSION[0] == 1 and django.VERSION[1] >= 7:
@@ -19,9 +21,8 @@ if django.VERSION[0] == 1 and django.VERSION[1] >= 7:
 
         def process_lhs(self, qn, connection):
             lhs_sql, params = super(ILike, self).process_lhs(qn, connection)
-            backend_name = backend.__name__
-            if 'postgres' in backend_name or \
-               'oracle' in backend_name:
+            if 'postgres' in _backend_name or \
+               'oracle' in _backend_name:
                 lhs_sql = 'UPPER(%s)' % lhs_sql
             return (lhs_sql, params)
 
@@ -84,9 +85,8 @@ else:
         return self.lookup_cast_origin(lookup_type)
 
     def monkey_ilike():
-        backend_name = backend.__name__
-        if 'postgres' in backend_name or \
-           'oracle' in backend_name:
+        if 'postgres' in _backend_name or \
+           'oracle' in _backend_name:
             connection.ops.__class__.lookup_cast_origin = connection.ops.lookup_cast
             connection.ops.__class__.lookup_cast = lookup_cast
 


### PR DESCRIPTION
`django.db.backend` is no longer available on Django 1.8.

This PR instead uses the `vendor` attribute of the database connection. I hope this works everywhere but if it does it would also warrant a new pypi release.
